### PR TITLE
fix: Expose database url in workflow run

### DIFF
--- a/.github/workflows/db-keepalive.yaml
+++ b/.github/workflows/db-keepalive.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Every 6 days at midnight
     - cron: "0 0 */6 * *"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,4 +21,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run tests
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm db:prevent-sleep

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --watch --silent",
     "test:ci": "next lint && jest",
     "db:push": "prisma db push",
-    "db:prevent-sleep": "node ./scripts/db-keepalive.js",
+    "db:keepalive": "node ./scripts/db-keepalive.js",
     "generate": "prisma generate",
     "COMMENT: This is done to fix builds on vercel": "",
     "COMMENT: See: https://pris.ly/d/vercel-build": "",


### PR DESCRIPTION
This also adds a workflow_dispatch option in case we need to run it on the go.